### PR TITLE
Alter behavior of rules jsx-filename-extension and new-cap

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,12 @@
 {
-  "extends": "airbnb"
+  "extends": "airbnb",
+  "rules": {
+      "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+      "new-cap": [
+        "error",
+        {
+          "capIsNew": false
+        }
+      ]
+    }
 }


### PR DESCRIPTION
No more eslint errors for `.js` files with jsx in them

Calling functions with capitalized names without the `new` keyword no longer errors
Using the `new` keyword still requires the function name to be capitalized

This will error:

```javascript
new circle();
```

This will not error:

```javascript
new Circle();
```
Or

```javascript
const circle = Circle()
```